### PR TITLE
Velma Features and Bug Fixes

### DIFF
--- a/adr_gui/adr_gui.py
+++ b/adr_gui/adr_gui.py
@@ -541,10 +541,10 @@ class ADR_Gui(PyQt5.QtWidgets.QMainWindow):
                 setpoint = tc.getTemperatureSetPoint() 
                 temperror = self.tempControl.getTempError()
                 if control_mode == 'closed' and\
-                ramp_status == 'on' and\
-                0<ramp_rate<.2 and\
-                0.04<setpoint<0.35 and\
-                numpy.abs(temperror)<0.005:
+                 ramp_status == 'on' and\
+                 0<ramp_rate<.2 and\
+                 0.04<setpoint<0.80 and\
+                 numpy.abs(temperror)<0.005:
                     print(("started with heater out %0.2f, but determined it is already in control state"%self.lastHOut))
                     print("STARTING IN CONTROL STATE")
                     self.heatSwitchIsClosedCheckBox.setCheckState(Qt.Unchecked)
@@ -555,6 +555,7 @@ class ADR_Gui(PyQt5.QtWidgets.QMainWindow):
                     warningBox = QMessageBox()
                     warningBox.setText("Warning heater out is %0.2f, should be zero in initial state (unless its in closed loop control).  Manually correct system and try again.  Will exit after this."%self.lastHOut)
                     warningBox.exec_()
+                    print(ramp_status, control_mode, ramp_rate, setpoint)
                     sys.exit()
             elif self.adrShouldMagup(self.startTimeEdit.value, self.startOutEdit.value, self.lastHOut):
                 self.SIG_startgoingToMagUp.emit()

--- a/adr_gui/adr_gui.py
+++ b/adr_gui/adr_gui.py
@@ -259,7 +259,7 @@ class ADR_Gui(PyQt5.QtWidgets.QMainWindow):
         self.tempControl = tempControl.TempControl(PyQt5.QtWidgets.QApplication,0.001,
         controlThermExcitation=self.currentExcitationCurrent,
         channel = self.controlChannel)
-        
+        self.tempControl.a.temperature_controller.serial.flush()
         p, i, d = self.tempControl.a.temperature_controller.getPIDValues()
         _, r = self.tempControl.a.temperature_controller.getRamp()
         self.pidr = [p, i, d, r] 

--- a/adr_gui/adr_gui.py
+++ b/adr_gui/adr_gui.py
@@ -259,7 +259,7 @@ class ADR_Gui(PyQt5.QtWidgets.QMainWindow):
         self.tempControl = tempControl.TempControl(PyQt5.QtWidgets.QApplication,0.001,
         controlThermExcitation=self.currentExcitationCurrent,
         channel = self.controlChannel)
-
+        
         p, i, d = self.tempControl.a.temperature_controller.getPIDValues()
         _, r = self.tempControl.a.temperature_controller.getRamp()
         self.pidr = [p, i, d, r] 
@@ -706,7 +706,11 @@ class ADR_Gui(PyQt5.QtWidgets.QMainWindow):
     def pollTempControl(self):
         self.lastTemp_K = self.tempControl.getTemp()
         self.lastHOut = self.tempControl.getHeaterOut()
-        lj_volts = self.tempControl.a.magnet_control_relay.getAnalogInput(6,verbose=False)
+        try:
+            lj_volts = self.tempControl.a.magnet_control_relay.getAnalogInput(6,verbose=False)
+        except:
+            self.tempControl.a.magnet_control_relay.lj.configAnalog(6) # Current sense pin
+            lj_volts = self.tempControl.a.magnet_control_relay.getAnalogInput(6,verbose=False)
         lj_current = lj_volts * (3278+9950) / 3278  # measured resistor values are 3278 and 9950 ohms
         self.lastCurrentReading = lj_current
         logger.log("%s, %f, %f, %f, %f"%(time.asctime(),time.time(), self.lastTemp_K, self.lastHOut, self.lastCurrentReading))

--- a/cringe/cringe.py
+++ b/cringe/cringe.py
@@ -1014,8 +1014,9 @@ class Cringe(QtWidgets.QWidget):
         self.tune_widget.mm.changedfbrow(col=int(col), row="master", d2aA=int(fba_offset))
         return True, ""
 
-
-
+    def rpc_set_seq_len(self, length):
+        self.seqln_spin.setValue(int(length))
+        return True, ""
 
     def seqln_changed(self):
         if self.seqln_timer == None:

--- a/cringe/cringe.py
+++ b/cringe/cringe.py
@@ -2439,6 +2439,9 @@ class Cringe(QtWidgets.QWidget):
     def unpackTune(self):
         self.tune_widget.unpackState(self.loadTune["TuneParameters"])
 
+    def closeEvent(self,event):
+        self.saveSettings()
+        event.accept()
 
 def main():
 

--- a/cringe/cringe_control.py
+++ b/cringe/cringe_control.py
@@ -17,7 +17,8 @@ CRINGE_COMMANDS = {
     'set_fba_offset':{'fname':'rpc_set_fba_offset', 'args':['col', 'fba_offset'], 'help':'set fba_offset for all rows in this column'},
     'set_fb_i':{'fname':'rpc_set_fb_i', 'args':['col', 'fb_i'], 'help':'set feedback parameter I for all rows in this column'},
     'set_tower_channel':{'fname':'rpc_set_tower_channel', 'args':['cardname', 'bayname', 'dacvalue'], 'help':'set the dac value for a tower card by cardname and bayname (strings)'},
-    'set_tower_card_all_channels':{'fname':'rpc_set_tower_card_all_channels', 'args':['cardname', 'dacvalue'], 'help':'set the dac value for all tower channels in one card'}
+    'set_tower_card_all_channels':{'fname':'rpc_set_tower_card_all_channels', 'args':['cardname', 'dacvalue'], 'help':'set the dac value for all tower channels in one card'},
+    'set_sequence_length':{'fname':'rpc_set_seq_len', 'args':['length'], 'help':'Set the number of rows to read.'}
 #    'devtest':{'fname':'devtest', 'args':['arg1'], 'help':'temporary for development testing'},      
 #    'cmd':{'fname':name, 'args':[], 'help':''},      
     }
@@ -74,6 +75,8 @@ class CringeControl:
     def relock_all_locked_fba(self, col):
         return self.send(" ".join(("relock_all_locked_fba", str(int(col)))))
 
+    def set_sequence_length(self, length):
+        return self.send(" ".join(("set_sequence_length", str(int(length)))))
 
     def test(self):
         command = 'devtest'

--- a/cringe/tower/towerchannel.py
+++ b/cringe/tower/towerchannel.py
@@ -32,7 +32,7 @@ class TowerChannel(QWidget):
         self.dacspin.setRange(0, 65535)
         self.dacspin.setFixedWidth(70)
         self.dacspin.setFixedHeight(25)
-        self.dacspin.setSingleStep(250)
+        self.dacspin.setSingleStep(25)
         self.dacspin.setKeyboardTracking(0)
         self.dacspin.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.layout.addWidget(self.dacspin)

--- a/detchar/acquire.py
+++ b/detchar/acquire.py
@@ -43,10 +43,11 @@ class Acquire():
         self.adr = adr_control or AdrGuiControl()
         self.acq_delay = delay_between_acqs
         self.relock_bounds = relock_bounds
+        self.col = data_column
         if relock_bounds[1] - relock_bounds[0] < 2000:
             raise ValueError("Insufficient range for relock!")
 
-        if db_source == 'tower':
+        if db_source == 'tower' or db_source is None:
             self.is_tower = True  # 0-2.5V in 2**16 steps
         elif db_source == 'bluebox':
             self.is_tower = False

--- a/detchar/alias.config
+++ b/detchar/alias.config
@@ -1,0 +1,30 @@
+ # config file for IV acquisition
+io:
+    RootPath: ./ #data stored here (be sure to put "/" at end)
+    SaveTo: test_alias_4.json
+
+detectors:
+    DetectorName: taurus_dualtes_testchip
+    Column: C
+    Rows: [12,13,16,17,20,21]
+  # Record the line period to row select map within TDM frame, as it is not commanded.
+
+voltage_bias:
+    source: 'tower'
+    db_cardname: 'DB' # this is static for velma and only used if source=='tower'
+    
+runconfig:
+    show_plot: True
+    save_data: True
+    seq_len_list: [6,12,18,24,48,64]
+    min_freq: 1
+    n_avg: 10
+    mix_fraction: 1
+
+calnums:
+    rfb: 206.9 # 1186 # do not include 50 Ohm output
+    rbias: 1207.0
+    rjnoise: 0.000150
+    mr: 15
+    mrsh: 0
+    vfb_gain: 1.017

--- a/detchar/alias.py
+++ b/detchar/alias.py
@@ -1,8 +1,9 @@
 from detchar.noise import NoiseAcquire
 
 import time
-from nasa_client import EasyClient
+from nasa_client import RpcError
 from cringe.cringe_control import CringeControl
+import yaml
 """
 The idea here will be:
 1. have Dastard stop data acquisition, 
@@ -15,32 +16,57 @@ The end result will be lots of noise PSDs of different
 lengths, which could be annoying.
 
 The challenges could be:
-    Can Cringe Control even set the sequence length in the first place?
-    How much resetting do we need to do when the seq length is changed
-    Can we be sure that the first X rows stay the same?
-    Does it matter what rows we read in the meantime?
-    Best way to interface with Dastard? Can Dastard handle multiple connections at once?
-    Every time data stops and starts in Dastard Commander the trigger parameters are reset
-    when data is stopped and started the mix config is lost
+    [x] Can Cringe Control even set the sequence length in the first place?
+    [ ] How much resetting do we need to do when the seq length is changed
+    [ ] Can we be sure that the first X rows stay the same?
+    [ ] Does it matter what rows we read in the meantime?
+    [x] Best way to interface with Dastard? Can Dastard handle multiple connections at once?
+    [x] Every time data stops and starts in Dastard Commander the trigger parameters are reset
+    [x] when data is stopped and started the mix config is lost
 
 """
 
-print("WIP: Testing Easy Client")
+class AliasSweep:
+    def __init__(self, noise_acquire):
+        self.na = noise_acquire
+        self.ec = self.na.ec
+        self.cc = self.na.cc
 
-ec = EasyClient()
+    def set_length(self, new_length):
+        try:
+            print("Stopping Dastard data to change sequence length...")
+            self.ec.stop_data()
+        except RpcError as e:
+            print(e)
 
-try:
-    ec.stop_data()
-except:
-    print("Exception probably source not active")
-else:
-    time.sleep(5)
+        print("Commanding new seq length in Cringe...")
+        self.cc.set_sequence_length(new_length)
 
-cc = CringeControl()
-cc.set_sequence_length(40)
+        time.sleep(2) # Empirically determined wait time. 1 s is too short.
 
-time.sleep(2)
-print("Attempting to start Lancero:")
+        print("Attempting to restart Lancero data in Dastard...")
+        ec.start_data_lancero()
+        ec._getStatus() # updates things like sample time
+        ec.setMix(self.mix_fraction)
 
+    def run(self, seq_len_list):
+        noise_data = []
+        for i in seq_len_list:
+            self.set_length(i)
+            noise_data.append(self.na.take(extra_info={"seq_len":i}))
 
-ec.start_data_lancero()
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(description='Take noise spectra at varying row-revisit rates')
+    parser.add_argument('file', type=str, help="configuration yaml file")
+    args = parser.parse_args()
+    na = NoiseAcquire.from_yaml(args.file)
+    with open(args.file,'r') as yml:
+        config = yaml.load(yml, Loader=yaml.FullLoader)
+    alias_sweeper = AliasSweep(na)
+    data_list = alias_sweeper.run(config['runconfig']['seq_len_list'])
+    if config['runconfig']['show_plot']:
+        fig = None
+        ax = None
+        for data in data_list:
+            fig, ax = data.plot_avg_psd(row_index = config['detectors']['Rows'], fig = fig, ax = ax)
+

--- a/detchar/alias.py
+++ b/detchar/alias.py
@@ -75,15 +75,15 @@ class AliasSweep:
             self.cc.relock_all_locked_fba(self.na.db_bay)
             noise_data.append(self.na.take(extra_info={"seq_len":i}))
         kludged_noise_sweep_data = NoiseSweepData(
-            data = noise_data,
+            data = [noise_data],
             column = self.na.column,
             row_sequence = self.na.row_sequence,
             signal_column_index = self.na.column,
             db_cardname = self.na.db_cardname,
             db_tower_channel_str = self.na.db_bay,
-            temp_settle_delay_s = None,
-            temp_list_k = [None],
-            db_list = [[None]],
+            temp_settle_delay_s = 1e-30,
+            temp_list_k = [1e-30],
+            db_list = [[1]],
             extra_info={
                 'seq_len_list': seq_len_list,
                 'type': 'Alias Sweep'

--- a/detchar/alias.py
+++ b/detchar/alias.py
@@ -1,9 +1,13 @@
 from detchar.noise import NoiseAcquire
-
+import argparse
 import time
 from nasa_client import RpcError
 from cringe.cringe_control import CringeControl
 import yaml
+import collections
+from matplotlib import pyplot as plt
+from detchar.iv_data import NoiseSweepData
+import os
 """
 The idea here will be:
 1. have Dastard stop data acquisition, 
@@ -18,19 +22,28 @@ lengths, which could be annoying.
 The challenges could be:
     [x] Can Cringe Control even set the sequence length in the first place?
     [ ] How much resetting do we need to do when the seq length is changed
-    [ ] Can we be sure that the first X rows stay the same?
-    [ ] Does it matter what rows we read in the meantime?
+        so far:
+        - mix fraction
+        - easyClient needs to reset number of rows etc
+        - relock feedback?
+        - Do we need new I values??
+    [x] Can we be sure that the first X rows stay the same?
+    [x] Does it matter what rows we read in the meantime?
     [x] Best way to interface with Dastard? Can Dastard handle multiple connections at once?
     [x] Every time data stops and starts in Dastard Commander the trigger parameters are reset
     [x] when data is stopped and started the mix config is lost
 
+Issues:
+    [ ] Dastard Commander will crash when this script is running.
+
 """
 
 class AliasSweep:
-    def __init__(self, noise_acquire):
+    def __init__(self, noise_acquire, mix_fraction):
         self.na = noise_acquire
         self.ec = self.na.ec
         self.cc = self.na.cc
+        self.mix_fraction = mix_fraction
 
     def set_length(self, new_length):
         try:
@@ -45,15 +58,38 @@ class AliasSweep:
         time.sleep(2) # Empirically determined wait time. 1 s is too short.
 
         print("Attempting to restart Lancero data in Dastard...")
-        ec.start_data_lancero()
-        ec._getStatus() # updates things like sample time
-        ec.setMix(self.mix_fraction)
+        self.ec.start_data_lancero()
+        reported_seq_len = None
+        while reported_seq_len != new_length:
+            self.ec.messagesSeen = collections.Counter() # Makes sure that the
+            # client actually waits for a new status message 
+            self.ec._getStatus() # updates things like sample time
+            reported_seq_len = self.ec.sequenceLength
+            time.sleep(1)
+        self.ec.setMix(self.mix_fraction)
 
     def run(self, seq_len_list):
         noise_data = []
         for i in seq_len_list:
             self.set_length(i)
+            self.cc.relock_all_locked_fba(self.na.db_bay)
             noise_data.append(self.na.take(extra_info={"seq_len":i}))
+        kludged_noise_sweep_data = NoiseSweepData(
+            data = noise_data,
+            column = self.na.column,
+            row_sequence = self.na.row_sequence,
+            signal_column_index = self.na.column,
+            db_cardname = self.na.db_cardname,
+            db_tower_channel_str = self.na.db_bay,
+            temp_settle_delay_s = None,
+            temp_list_k = [None],
+            db_list = [[None]],
+            extra_info={
+                'seq_len_list': seq_len_list,
+                'type': 'Alias Sweep'
+            }
+        )
+        return kludged_noise_sweep_data
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser(description='Take noise spectra at varying row-revisit rates')
@@ -62,11 +98,16 @@ if __name__=="__main__":
     na = NoiseAcquire.from_yaml(args.file)
     with open(args.file,'r') as yml:
         config = yaml.load(yml, Loader=yaml.FullLoader)
-    alias_sweeper = AliasSweep(na)
-    data_list = alias_sweeper.run(config['runconfig']['seq_len_list'])
+    if os.path.isfile(config['io']['SaveTo']):
+        raise OSError("File exists")
+    alias_sweeper = AliasSweep(na, config['runconfig']['mix_fraction'])
+    nsd = alias_sweeper.run(config['runconfig']['seq_len_list'])
+    if config['runconfig']['save_data']:
+        nsd.to_file(filename=config['io']['SaveTo'])
     if config['runconfig']['show_plot']:
         fig = None
         ax = None
+        data_list = nsd.data
         for data in data_list:
-            fig, ax = data.plot_avg_psd(row_index = config['detectors']['Rows'], fig = fig, ax = ax)
-
+            fig, ax = data.plot_avg_psd(fig = fig, ax = ax,row_index = list(range(len(na.row_sequence))))
+        plt.show()

--- a/detchar/alias.py
+++ b/detchar/alias.py
@@ -1,0 +1,46 @@
+from detchar.noise import NoiseAcquire
+
+import time
+from nasa_client import EasyClient
+from cringe.cringe_control import CringeControl
+"""
+The idea here will be:
+1. have Dastard stop data acquisition, 
+2. tell Cringe to increase sequence length, 
+3. have Dastard start acquisition again 
+4. collect noise PSD
+5. repeat
+
+The end result will be lots of noise PSDs of different
+lengths, which could be annoying.
+
+The challenges could be:
+    Can Cringe Control even set the sequence length in the first place?
+    How much resetting do we need to do when the seq length is changed
+    Can we be sure that the first X rows stay the same?
+    Does it matter what rows we read in the meantime?
+    Best way to interface with Dastard? Can Dastard handle multiple connections at once?
+    Every time data stops and starts in Dastard Commander the trigger parameters are reset
+    when data is stopped and started the mix config is lost
+
+"""
+
+print("WIP: Testing Easy Client")
+
+ec = EasyClient()
+
+try:
+    ec.stop_data()
+except:
+    print("Exception probably source not active")
+else:
+    time.sleep(5)
+
+cc = CringeControl()
+cc.set_sequence_length(40)
+
+time.sleep(2)
+print("Attempting to start Lancero:")
+
+
+ec.start_data_lancero()

--- a/detchar/ivCurveAcquire.py
+++ b/detchar/ivCurveAcquire.py
@@ -122,21 +122,23 @@ def main():
     #     bath_temps = [ls370.getTemperatureSetPoint()]
 
     #############
-    if type(bayname) is list:
-        pt_taker = iv.IVPointTakerMulti(
+    #if type(bayname) is list:
+    pt_taker = iv.IVPointTakerMulti(
             db_cardname=cfg['voltage_bias']['db_cardname'],
             bayname=bayname,
             voltage_source=voltage_source,
-            column_number=[0,1,2]
+            column_number=[1,2]
         )
-    else:
-        pt_taker = iv.IVPointTaker(db_cardname=cfg['voltage_bias']['db_cardname'], bayname=bayname, voltage_source = voltage_source)
+    # else:
+    #     pt_taker = iv.IVPointTaker(db_cardname=cfg['voltage_bias']['db_cardname'], 
+    #       bayname=bayname, 
+    #       voltage_source = voltage_source,
+    #       relock_threshold_lo_hi = (4000, 14000))
     curve_taker = iv.IVCurveTaker(
         pt_taker, 
         temp_settle_delay_s=cfg['runconfig']['temp_settle_delay_s'], 
         shock_normal_dac_value=cfg['voltage_bias']['shock_normal_dac_value'], 
-        zero_tower_at_end=cfg['voltage_bias']['setVtoZeroPostIV'], 
-        adr_gui_control=None
+        zero_tower_at_end=cfg['voltage_bias']['setVtoZeroPostIV']
     )
     curve_taker.prep_fb_settings(I=cfg['dfb']['i'], fba_offset=cfg['dfb']['dac_a_offset'], ARLoff=True)
     ivsweeper = iv.IVTempSweeper(curve_taker, to_normal_method=to_normal_method, overbias_temp_k=overbias_temp_k, overbias_dac_value = cfg['voltage_bias']['v_start_dac'])

--- a/detchar/iv_utils.py
+++ b/detchar/iv_utils.py
@@ -62,14 +62,14 @@ class IVPointTaker(Acquire):
         #data = self.ec.getNewData(delaySeconds=self.delay_s)
         # GCJ debugging this with try/except/finally
         try:
-            data = self.ec.getNewData(delaySeconds=self.delay_s,minimumNumPoints=16,exactNumPoints=True)
+            data = self.ec.getNewData(delaySeconds=self.acq_delay,minimumNumPoints=16,exactNumPoints=True)
         except:
             print('\ngetNewData failed, trying once more')
             try:
-                data = self.ec.getNewData(delaySeconds=self.delay_s,minimumNumPoints=16,exactNumPoints=True)
+                data = self.ec.getNewData(delaySeconds=self.acq_delay,minimumNumPoints=16,exactNumPoints=True)
             except:
                 print('\ngetNewData failed again, trying one last time')
-                data = self.ec.getNewData(delaySeconds=self.delay_s,minimumNumPoints=16,exactNumPoints=True)             
+                data = self.ec.getNewData(delaySeconds=self.acq_delay,minimumNumPoints=16,exactNumPoints=True)             
         avg_col = data[self.col,:,:,1].mean(axis=-1)
         rows_relocked_hi = []
         rows_relocked_lo = []
@@ -84,7 +84,7 @@ class IVPointTaker(Acquire):
         if len(rows_relocked_lo)+len(rows_relocked_hi) > 0:
             # at least one relock occured
             print(f"\nrelocked rows: too low {rows_relocked_lo}, too high {rows_relocked_hi}")
-            data_after = self.ec.getNewData(delaySeconds=self.delay_s,minimumNumPoints=16,exactNumPoints=True)
+            data_after = self.ec.getNewData(delaySeconds=self.acq_delay,minimumNumPoints=16,exactNumPoints=True)
             avg_col_after = data_after[self.col,:,:,1].mean(axis=-1)
             for row in rows_relocked_lo+rows_relocked_hi:
                 self._relock_offset[row] += avg_col_after[row]-avg_col[row]
@@ -114,7 +114,7 @@ class IVPointTakerMulti(IVPointTaker):
 
     def get_iv_pt(self, dacvalue):
         self.set_volt(dacvalue)
-        time.sleep(self.delay_s)
+        time.sleep(self.acq_delay)
         data = self.ec.getNewData2(16)
         numChans = self.ec.numRows*self.ec.numColumns
         processed_data = np.zeros(numChans)
@@ -128,7 +128,7 @@ class IVPointTakerMulti(IVPointTaker):
                 self.cc.relock_fba(i // self.ec.numRows, i % self.ec.numRows)
         
         if len(relocked_chans) > 0:
-            time.sleep(self.delay_s)
+            time.sleep(self.acq_delay)
             post_relock_data = self.ec.getNewData2(16)
             print(f"Relocked: {relocked_chans}")
             for i in relocked_chans:

--- a/detchar/noise.py
+++ b/detchar/noise.py
@@ -330,6 +330,13 @@ class NoiseSweep(NoiseAcquire):
                               temp_settle_delay_s=self.temp_settle_delay_s,
                               extra_info=extra_info)
             if tmp_file is not None:
+                # This slows the script a little, but it's way better than
+                # having the script crash and discard all the data it collected
+                # so far. And maybe we can even do it while changing temperature.
+                try:
+                    self.set_temp(self.temp_list_k[ii+1])
+                except IndexError:
+                    pass
                 nsd.to_file(filename=tmp_file,overwrite=True)
             
         return nsd
@@ -393,6 +400,7 @@ if __name__ == "__main__":
             temp_settle_delay_s = config["runconfig"]["temp_settle_delay_s"]
         )
         nd=ns.run(tmp_file = config['io']['SaveTo']+'.tmp')
+        ns.set_temp(0.1)
         for i in range(len(config['detectors']['Rows'])):
             nd.plot_row(i)
             plt.show()

--- a/detchar/noise.py
+++ b/detchar/noise.py
@@ -114,8 +114,25 @@ class NoiseAcquire(acquire.Acquire):
     ''' Acquire multiplexed, averaged noise data.
         No sensor setup is done.
     '''
+    @classmethod
+    def from_yaml(cls, yaml):
+        with open(yaml, 'r') as ymlfile:
+            config = yaml.load(yml, Loader=yaml.FullLoader)
+        column = acquire.column_name_to_num(config['detectors']['Column'])
+        return cls(
+            column_str = config['detectors']['Column'],
+            row_sequence_list = config['detectors']['Rows'],
+            m_ratio = config['calnums']['mr'],
+            rfb_ohm = config['calnums']['rfb'],
+            f_min_hz = config['runconfig']['min_freq'],
+            num_averages = config['runconfig']['n_avg'],
+            db_source = config['voltage_bias']['source'],
+            db_card = config['voltage_bias']['db_cardname'],
+            db_bay = column
+        )
+ 
     def __init__(self, 
-                 column_str, 
+                 column_str, # Only used in metadata recording
                  row_sequence_list, 
                  m_ratio, 
                  rfb_ohm, 
@@ -224,7 +241,6 @@ class NoiseAcquire(acquire.Acquire):
             ax.loglog(self.freqs,self.Pxx_all[row_index,:,ii])
         ax.set_xlabel('Frequency (Hz)')
         ax.legend(range(self.num_averages))
-
 
     # def _init_ui(self):
     #     ''' initialize UI '''

--- a/detchar/noise.py
+++ b/detchar/noise.py
@@ -115,9 +115,9 @@ class NoiseAcquire(acquire.Acquire):
         No sensor setup is done.
     '''
     @classmethod
-    def from_yaml(cls, yaml):
-        with open(yaml, 'r') as ymlfile:
-            config = yaml.load(yml, Loader=yaml.FullLoader)
+    def from_yaml(cls, yml_filename):
+        with open(yml_filename, 'r') as ymlfile:
+            config = yaml.load(ymlfile, Loader=yaml.FullLoader)
         column = acquire.column_name_to_num(config['detectors']['Column'])
         return cls(
             column_str = config['detectors']['Column'],

--- a/instruments/zaber.py
+++ b/instruments/zaber.py
@@ -174,6 +174,12 @@ class Zaber(serial_instrument.SerialInstrument):
 
 
     def SetHoldCurrent(self, current=0):
+        if self.serial.in_waiting > 0:
+            oldtimeout = self.serial.timeout
+            self.serial.timeout=0.1
+            junk_data=self.serial.read(self.serial.in_waiting)
+            print(f"junk data in buffer: {repr(junk_data)}")
+            self.serial.timeout = oldtimeout
         #set running current
         #set running current Range 0, 10-127   0: no current, 10 max , 127 min
         self.__sendCommandParseReply(value=current, command=39)

--- a/nasa_client/__init__.py
+++ b/nasa_client/__init__.py
@@ -1,3 +1,4 @@
 from .client import Client
 from .easyClient import EasyClient
 from .rpc_client_for_easy_client import JSONClient
+from .rpc_client_for_easy_client import RpcError

--- a/nasa_client/easyClientDastard.py
+++ b/nasa_client/easyClientDastard.py
@@ -68,6 +68,8 @@ class EasyClientDastard():
                     self.numRows = self.sequenceLength
                     self.numColumns = self.numChannels//(2*self.numRows)
                     assert self.numChannels%(2*self.numRows) == 0
+                    self.linePeriodSeconds = self.linePeriod/self.clockMhz
+                    self.samplePeriod = self.linePeriodSeconds*self.numRows
                 if self.sourceName == "SimPulses":
                     self.numColumns = 1
                     self.numRows = self.numChannels
@@ -121,8 +123,6 @@ class EasyClientDastard():
         self._connectRPC()
         self._connectStatusSub()
         self._getStatus()
-        self.linePeriodSeconds = self.linePeriod/self.clockMhz
-        self.samplePeriod = self.linePeriodSeconds*self.numRows
         if DEBUG:
             print("setupAndChooseChannels prints:")
             print(self)

--- a/nasa_client/easyClientDastard.py
+++ b/nasa_client/easyClientDastard.py
@@ -26,7 +26,7 @@ class EasyClientDastard():
         self.baseport = baseport
         self.context = zmq.Context()
         self.samplePeriod = None # learn this from first observed data packet
-        self._restoredOldTriggerSettings = False
+        self._restoredOldTriggerSettings = False # unused?
         if setupOnInit:
             self.setupAndChooseChannels()
 
@@ -105,6 +105,13 @@ class EasyClientDastard():
             self.clockMhz = d["DastardOutput"]["ClockMHz"]
             self.sequenceLength = d["DastardOutput"]["SequenceLength"]
             self.linePeriod = d["DastardOutput"]["Lsync"]
+            self.lancero_config = { # These are the parameters used to set up Lancero. Copied from dc.py
+                "ClockMHz": self.clockMhz,
+                "Nsamp": self.nSamp,
+                "AvailableCards":[]
+            }
+            for key in ["FiberMask","CardDelay","ActiveCards","ChanSepCards","ChanSepColumns","FirstRow"]:
+                self.lancero_config[key] = d[key]
         if topic == "TRIGGER":
             self._oldTriggerDict = d[0]
 
@@ -119,6 +126,23 @@ class EasyClientDastard():
         if DEBUG:
             print("setupAndChooseChannels prints:")
             print(self)
+
+    def start_data_lancero(self):
+        # Start lancero card with same settings as used before
+
+        self.rpc.call("SourceControl.ConfigureLanceroSource",self.lancero_config)
+        ok = self.rpc.call("SourceControl.Start", "LANCEROSOURCE")
+        if not ok:
+            print("Could not start data!")
+
+        return ok
+
+    def stop_data(self):
+        ok = self.rpc.call("SourceControl.Stop","")
+        if not ok:
+            print("Could not stop data!")
+
+        return ok
 
     @property
     def channelIndicies(self):

--- a/nasa_client/rpc_client_for_easy_client.py
+++ b/nasa_client/rpc_client_for_easy_client.py
@@ -2,6 +2,8 @@ import json
 import itertools
 import socket
 DEBUG = False
+class RpcError(Exception):
+    pass
 
 class JSONClient(object):
     def __init__(self, addr, codec=json, qtParent = None):
@@ -46,7 +48,7 @@ class JSONClient(object):
             print(response)
 
         if response.get('id') != id:
-            raise Exception("expected id=%s, received id=%s: %s" %
+            raise RpcError("expected id=%s, received id=%s: %s" %
                             (id, response.get('id'),
                              response.get('error')))
 
@@ -55,7 +57,7 @@ class JSONClient(object):
                 print(("Yikes! Request is: ", request))
                 print(("Reponse is: ", response))
             if self.qtParent is None:
-                raise Exception(response.get('error'))
+                raise RpcError(response.get('error'))
             else:
                 em = QtWidgets.QErrorMessage(self.qtParent)
                 em.showMessage("DASTARD Error: \n%s"%response.get('error'))


### PR DESCRIPTION
This adds a couple of quality of life features and bug fixes:
 - When Cringe is closed, it will pop up with a save file dialog to ensure you don't accidentally quit without saving
 - `alias.py` can be used to collect noise data with varying sequence lengths (i.e. number of rows) to estimate the alias penalty. 
   - This includes additional functionality in the cringe control API to allow scripts to command the sequence length
   - Also there is now a function in the easy client to command Dastard to stop and start data. (Dastard will crash if the sequence length is changed while data is running)
   - NOTE: alias.py will crash Dastard Commander. Just boot it back up again when you're done.
 - Change the logic in `adr_gui` `safeautorange` function to prevent repeated duplicate commands sent to lakeshore
 - various I/O error handling fixes for serial and labjack communication